### PR TITLE
Error handling for invalid credentials

### DIFF
--- a/lib/matroid.js
+++ b/lib/matroid.js
@@ -31,12 +31,14 @@ class Matroid {
       'User-Agent': 'request'
     };
 
+    /* eslint-disable no-magic-numbers */
     this._fileSizeLimits = {
       image: 50 * 1024 * 1024,
       video: 300 * 1024 * 1024,
       imageBatch: 50 * 1024 * 1024,
       zip: 300 * 1024 * 1024
     };
+    /* eslint-enable no-magic-numbers */
   }
 
   /*
@@ -75,7 +77,7 @@ class Matroid {
         requestConfigs.data.refresh = 'true';
       }
 
-      this._genericRequest(requestConfigs, this._setAuthToken.bind(this, resolve), reject);
+      this._genericRequest(requestConfigs, this._setAuthToken.bind(this, resolve, reject), reject);
     });
   }
 
@@ -240,8 +242,7 @@ class Matroid {
     });
   }
 
-  monitorStream(streamId, detectorId, configs) {
-    configs = configs || {};
+  monitorStream(streamId, detectorId, configs = {}) {
     return new Promise((resolve, reject) => {
       if (!streamId || !detectorId) {
         throw new Error(`Need to pass in a stream id and a detector id`);
@@ -287,10 +288,10 @@ class Matroid {
     config = this._setData(config, data, method, filePaths);
 
     request(config, (err, res, body) => {
+      if (err) return reject(err);
+
       let result;
       shouldNotParse ? result = body : result = safeParse(body);
-
-      if (err) return reject(err);
 
       return resolve(result);
     });
@@ -362,13 +363,13 @@ class Matroid {
     }
   }
 
-  _setAuthToken(callback, token) {
+  _setAuthToken(resolve, reject, token) {
     if (!token || !token.token_type || !token.access_token) {
-      throw new Error(`Unable to extract token from ${util.inspect(token, false, null)}`);
+      reject(Error(`Unable to extract token from ${util.inspect(token, false, null)}`));
     }
     this.authorizationHeader = `${token.token_type} ${token.access_token}`;
 
-    return callback(token);
+    return resolve(token);
   }
 }
 
@@ -378,7 +379,7 @@ function safeParse(response) {
     if (typeof response === 'string') {
       result = JSON.parse(response);
     } else {
-      result = response
+      result = response;
     }
   } catch (e) {
     result = { code: 'server_err', message: 'Unable to parse server response' };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matroid",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Matroid API Node Library",
   "main": "lib/matroid.js",
   "keywords": [


### PR DESCRIPTION
Fix https://github.com/matroid/matroid-node/issues/3

Looks to me like the issue wasn't an error when resolving the promise (those errors should be caught in the `.catch` handler chained to the returned promise). It was that for invalid credentials, we were `throw`ing an error when we should have been `reject`ing in the promise with that error.

Thank you @newmanlucy for the catch!