### PR TITLE
Update Node client

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ api.retrieveToken()
 
 // Check how many Matroid Credits you have
 api.retrieveToken()
-   .then(token => api.accountInfo())
+   .then(token => api.getAccountInfo())
    .then(account => console.log('Information: ', util.inspect(account, false, null)))
 
 // Register and monitor stream on Matroid
@@ -109,7 +109,7 @@ let monitorOptions = {
   'endpoint': 'http://mydomain.fake:9000/matroid_detections'
 }
 
-api.registerStream(streamUrl, 'backyard')
+api.createStream(streamUrl, 'backyard')
    .then(({ stream_id }) => api.monitorStream(stream_id, detectorId, monitorOptions))
    .then(monitoringInfo => console.log(monitoringInfo));
 ```

--- a/dist/src/accounts.js
+++ b/dist/src/accounts.js
@@ -5,31 +5,22 @@ var addAccountsApi = function addAccountsApi(matroid) {
   matroid.retrieveToken = function () {
     var _this = this;
 
-    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
     /*
     Generates an OAuth token. The API client will intelligently refresh the Access Token for you
-    However, if you would like to manually expire an existing token and create a new token,
-    call this method manually and pass in 'expireToken': true in the options argument.
-     In addition, you would have to refresh manually if another client has expired your access token.
-     You can pass the 'requestFromServer': true option to make a request
-    to the server for the access token without invalidating it. This is useful if you are running
-    multiple clients with the same token so they don't endlessly refresh each others' tokens
+    However, if you would like to manually create a new token,
+    call this method manually and pass in 'refresh': true in the options argument.
     */
     return new Promise(function (resolve, reject) {
-      var options = opts;
-      if (!options) options = {};
-
-      var _options = options,
-          expireToken = _options.expireToken,
-          requestFromServer = _options.requestFromServer;
+      var refresh = options.refresh;
 
 
-      if (_this.authorizationHeader && !(expireToken || requestFromServer)) {
+      if (_this.authorizationHeader && !refresh) {
         return resolve(_this.authorizationHeader);
       }
 
-      var requestConfigs = {
+      var requestOptions = {
         action: 'token',
         data: {
           client_id: _this.clientId,
@@ -39,21 +30,21 @@ var addAccountsApi = function addAccountsApi(matroid) {
         noAuth: true
       };
 
-      if (requestFromServer) {
-        requestConfigs.data.refresh = 'true';
+      if (refresh) {
+        requestOptions.data.refresh = 'true';
       }
 
-      _this._genericRequest(requestConfigs, _this._setAuthToken.bind(_this, resolve, reject), reject);
+      _this._genericRequest(requestOptions, _this._setAuthToken.bind(_this, resolve, reject), reject);
     });
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Accounts-GetAccount
-  matroid.getAccountInfo = function () {
+  matroid.accountInfo = function () {
     var _this2 = this;
 
     return new Promise(function (resolve, reject) {
       var options = {
-        action: 'getAccountInfo'
+        action: 'accountInfo'
       };
 
       _this2._genericRequest(options, resolve, reject);

--- a/dist/src/accounts.js
+++ b/dist/src/accounts.js
@@ -39,12 +39,13 @@ var addAccountsApi = function addAccountsApi(matroid) {
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Accounts-GetAccount
-  matroid.accountInfo = function () {
+  // Formerly called accountInfo (now deprecated), use getAccountInfo
+  matroid.getAccountInfo = matroid.accountInfo = function () {
     var _this2 = this;
 
     return new Promise(function (resolve, reject) {
       var options = {
-        action: 'accountInfo'
+        action: 'getAccountInfo'
       };
 
       _this2._genericRequest(options, resolve, reject);

--- a/dist/src/collections.js
+++ b/dist/src/collections.js
@@ -6,7 +6,7 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
     var _this = this;
 
     /*
-    Create an index on a collection with a detector
+    Creates an index on a collection with a detector.
     */
     return new Promise(function (resolve, reject) {
       _this._checkRequiredParams({ collectionId: collectionId, detectorId: detectorId, fileTypes: fileTypes });
@@ -25,8 +25,10 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
   matroid.createCollection = function (name, url, sourceType) {
     var _this2 = this;
 
+    var configs = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+
     /*
-    Creates a new collection from a web or S3 url. Automatically kick off default indexes
+    Creates a new collection from a web or S3 url.
     */
     return new Promise(function (resolve, reject) {
       _this2._checkRequiredParams({ name: name, url: url, sourceType: sourceType });
@@ -35,6 +37,12 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
         action: 'createCollection',
         data: { name: name, url: url, sourceType: sourceType }
       };
+
+      var indexWithDefault = configs.indexWithDefault;
+
+      if (indexWithDefault) {
+        options.data.indexWithDefault = indexWithDefault;
+      }
 
       _this2._genericRequest(options, resolve, reject);
     });
@@ -45,7 +53,7 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
     var _this3 = this;
 
     /*
-    Deletes a completed collection manager task
+    Deletes a completed collection task.
     */
     return new Promise(function (resolve, reject) {
       _this3._checkRequiredParams({ collectionTaskId: collectionTaskId });
@@ -64,7 +72,7 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
     var _this4 = this;
 
     /*
-    Deletes a collection with no active indexing tasks
+    Deletes a collection with no active indexing tasks.
     */
     return new Promise(function (resolve, reject) {
       _this4._checkRequiredParams({ collectionId: collectionId });
@@ -83,7 +91,7 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
     var _this5 = this;
 
     /*
-    Creates a new collection from a web or S3 url
+    Retrieves information about a specific collection task.
     */
     return new Promise(function (resolve, reject) {
       _this5._checkRequiredParams({ collectionTaskId: collectionTaskId });
@@ -102,7 +110,7 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
     var _this6 = this;
 
     /*
-    Get information about a specific collection
+    Retrieves information about a specific collection.
     */
     return new Promise(function (resolve, reject) {
       _this6._checkRequiredParams({ collectionId: collectionId });
@@ -121,7 +129,7 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
     var _this7 = this;
 
     /*
-    Kills an active collection indexing task
+    Kills an active collection indexing task.
     */
     return new Promise(function (resolve, reject) {
       _this7._checkRequiredParams({ collectionTaskId: collectionTaskId });
@@ -140,7 +148,7 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
     var _this8 = this;
 
     /*
-    Query against a collection index using a set of labels and scores as a query
+    Queries against a collection index using a set of labels and scores.
     */
     return new Promise(function (resolve, reject) {
       _this8._checkRequiredParams({ taskId: taskId, thresholds: thresholds, numResults: numResults });
@@ -162,7 +170,7 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
     var configs = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
     /*
-    Query against a collection index (CollectionManagerTask) using an image as key
+    Queries against a collection index using an image.
     */
     return new Promise(function (resolve, reject) {
       _this9._checkRequiredParams({ taskId: taskId, image: image });
@@ -184,13 +192,17 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
       }
 
       var numResults = configs.numResults,
-          boundingBox = configs.boundingBox;
+          boundingBox = configs.boundingBox,
+          shouldIndicateDuplicates = configs.shouldIndicateDuplicates;
 
       if (numResults) {
         options.data.numResults = numResults;
       }
       if (boundingBox) {
         options.data.boundingBox = JSON.stringify(boundingBox);
+      }
+      if (shouldIndicateDuplicates) {
+        options.data.shouldIndicateDuplicates = shouldIndicateDuplicates;
       }
 
       _this9._genericRequest(options, resolve, reject);

--- a/dist/src/collections.js
+++ b/dist/src/collections.js
@@ -156,7 +156,7 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
       var options = {
         action: 'queryCollectionByScores',
         uriParams: { ':key': taskId },
-        data: { numResults: numResults }
+        data: { thresholds: thresholds }
       };
       Object.assign(options.data, configs);
 

--- a/dist/src/collections.js
+++ b/dist/src/collections.js
@@ -144,20 +144,21 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
     });
   };
   // https://www.matroid.com/docs/api/index.html#api-Collections-PostApiVersionCollectionTasksTaskidScoresQuery
-  matroid.queryCollectionByScores = function (taskId, thresholds, numResults) {
+  matroid.queryCollectionByScores = function (taskId, thresholds, configs) {
     var _this8 = this;
 
     /*
     Queries against a collection index using a set of labels and scores.
     */
     return new Promise(function (resolve, reject) {
-      _this8._checkRequiredParams({ taskId: taskId, thresholds: thresholds, numResults: numResults });
+      _this8._checkRequiredParams({ taskId: taskId, thresholds: thresholds });
 
       var options = {
         action: 'queryCollectionByScores',
         uriParams: { ':key': taskId },
-        data: { thresholds: thresholds, numResults: numResults }
+        data: { numResults: numResults }
       };
+      Object.assign(options.data, configs);
 
       _this8._genericRequest(options, resolve, reject);
     });

--- a/dist/src/collections.js
+++ b/dist/src/collections.js
@@ -117,7 +117,7 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Collections-PostCollectionTasksTaskidKill
-  matroid.killCollectionIndex = function (collectionTaskId) {
+  matroid.killCollectionIndex = function (collectionTaskId, includeCollectionInfo) {
     var _this7 = this;
 
     /*
@@ -128,13 +128,13 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
 
       var options = {
         action: 'killCollectionIndex',
-        uriParams: { ':key': collectionTaskId }
+        uriParams: { ':key': collectionTaskId },
+        data: { includeCollectionInfo: includeCollectionInfo }
       };
 
       _this7._genericRequest(options, resolve, reject);
     });
   };
-
   // https://www.matroid.com/docs/api/index.html#api-Collections-PostApiVersionCollectionTasksTaskidScoresQuery
   matroid.queryCollectionByScores = function (taskId, thresholds, numResults) {
     var _this8 = this;
@@ -156,16 +156,16 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Collections-PostApiCollectionTasksTaskidImageQuery
-  matroid.queryCollectionByImage = function (taskId, taskType, numResults, image) {
+  matroid.queryCollectionByImage = function (taskId, image) {
     var _this9 = this;
 
-    var configs = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : {};
+    var configs = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
     /*
     Query against a collection index (CollectionManagerTask) using an image as key
     */
     return new Promise(function (resolve, reject) {
-      _this9._checkRequiredParams({ taskId: taskId, taskType: taskType, numResults: numResults, image: image });
+      _this9._checkRequiredParams({ taskId: taskId, image: image });
 
       _this9._validateImageObj(image);
       _this9._checkImageSize(image.file);
@@ -173,24 +173,32 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
       var options = {
         action: 'queryCollectionByImage',
         uriParams: { ':key': taskId },
-        data: { taskType: taskType, numResults: numResults }
+        data: {}
       };
 
-      if (image.file) options.filePaths = image.file;
-      if (image.url) Object.assign(options.data, { url: image.url });
+      if (image.file) {
+        options.filePaths = image.file;
+      }
+      if (image.url) {
+        Object.assign(options.data, { url: image.url });
+      }
 
-      var processedConfigs = configs;
-      var bbox = processedConfigs.boundingBox;
-      if (bbox) processedConfigs.boundingBox = JSON.stringify(bbox);
+      var numResults = configs.numResults,
+          boundingBox = configs.boundingBox;
 
-      Object.assign(options.data, processedConfigs);
+      if (numResults) {
+        options.data.numResults = numResults;
+      }
+      if (boundingBox) {
+        options.data.boundingBox = JSON.stringify(boundingBox);
+      }
 
       _this9._genericRequest(options, resolve, reject);
     });
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Collections-PutApiVersionCollectionTasksTaskid
-  matroid.updateCollectionIndex = function (collectionTaskId) {
+  matroid.updateCollectionIndex = function (collectionTaskId, updateIndex) {
     var _this10 = this;
 
     return new Promise(function (resolve, reject) {
@@ -198,7 +206,8 @@ var addCollectionsApi = function addCollectionsApi(matroid) {
 
       var options = {
         action: 'updateCollectionIndex',
-        uriParams: { ':key': collectionTaskId }
+        uriParams: { ':key': collectionTaskId },
+        data: { updateIndex: updateIndex }
       };
 
       _this10._genericRequest(options, resolve, reject);

--- a/dist/src/detectors.js
+++ b/dist/src/detectors.js
@@ -69,14 +69,15 @@ var addDetectorApi = function addDetectorApi(matroid) {
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Detectors-GetDetectorsDetector_id
-  matroid.detectorInfo = function (detectorId) {
+  // Formerly called detectorInfo (now deprecated), use getDetectorInfo
+  matroid.getDetectorInfo = matroid.detectorInfo = function (detectorId) {
     var _this4 = this;
 
     return new Promise(function (resolve, reject) {
       _this4._checkRequiredParams({ detectorId: detectorId });
 
       var options = {
-        action: 'detectorInfo',
+        action: 'getDetectorInfo',
         uriParams: { ':key': detectorId }
       };
 
@@ -206,6 +207,22 @@ var addDetectorApi = function addDetectorApi(matroid) {
       Object.assign(options.data, configs);
 
       _this7._genericRequest(options, resolve, reject);
+    });
+  };
+
+  // DEPRECATED - use searchDetectors now
+  matroid.listDetectors = function () {
+    var _this8 = this;
+
+    /*
+    Lists all detectors that are public or owned by the user.
+    */
+    return new Promise(function (resolve, reject) {
+      var options = {
+        action: 'listDetectors'
+      };
+
+      _this8._genericRequest(options, resolve, reject);
     });
   };
 };

--- a/dist/src/detectors.js
+++ b/dist/src/detectors.js
@@ -22,7 +22,7 @@ var addDetectorApi = function addDetectorApi(matroid) {
         filePaths: zipFile
       };
 
-      if (configs.detectorId) {
+      if (configs && configs.detectorId) {
         options.data.detectorId = configs.detectorId;
       }
 
@@ -50,7 +50,7 @@ var addDetectorApi = function addDetectorApi(matroid) {
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Detectors-PostDetectorsDetector_idFinalize
-  matroid.finalizeDetector = function (detectorId) {
+  matroid.trainDetector = function (detectorId) {
     var _this3 = this;
 
     /*
@@ -60,7 +60,7 @@ var addDetectorApi = function addDetectorApi(matroid) {
       _this3._checkRequiredParams({ detectorId: detectorId });
 
       var options = {
-        action: 'finalizeDetector',
+        action: 'trainDetector',
         uriParams: { ':key': detectorId }
       };
 
@@ -160,7 +160,7 @@ var addDetectorApi = function addDetectorApi(matroid) {
             Object.assign(options.data, { label_inds: labelInds });
           }
         } else {
-          throw new Error('Invalid paramter combination');
+          throw new Error('Invalid parameter combination');
         }
       }
 

--- a/dist/src/detectors.js
+++ b/dist/src/detectors.js
@@ -2,7 +2,7 @@
 
 var addDetectorApi = function addDetectorApi(matroid) {
   // https://www.matroid.com/docs/api/index.html#api-Detectors-PostDetectors
-  matroid.createDetector = function (zipFile, name, detectorType) {
+  matroid.createDetector = function (zipFile, name, detectorType, configs) {
     var _this = this;
 
     /*
@@ -18,9 +18,13 @@ var addDetectorApi = function addDetectorApi(matroid) {
 
       var options = {
         action: 'createDetector',
-        data: { name: name, detector_type: detectorType },
+        data: { name: name, detectorType: detectorType },
         filePaths: zipFile
       };
+
+      if (configs.detectorId) {
+        options.data.detectorId = configs.detectorId;
+      }
 
       _this._genericRequest(options, resolve, reject);
     });
@@ -88,8 +92,8 @@ var addDetectorApi = function addDetectorApi(matroid) {
 
     /* 
     Certain combination of parameters can be supplied: 
-    file_detector, file_proto + file_label(+ file_label_ind), 
-    or file_proto + labels(+ label_inds).
+    file_detector, fileProto + fileLabel(+ fileLabel_ind), 
+    or fileProto + labels(+ label_inds).
     Parentheses part can be optionally supplied for object detection.
     */
 
@@ -126,8 +130,8 @@ var addDetectorApi = function addDetectorApi(matroid) {
 
 
           Object.assign(options.filePaths, {
-            file_proto: fileProto,
-            file_label: fileLabel
+            fileProto: fileProto,
+            fileLabel: fileLabel
           });
           Object.assign(options.data, {
             input_tensor: inputTensor,
@@ -136,7 +140,7 @@ var addDetectorApi = function addDetectorApi(matroid) {
           });
           if (fileLabelInd) {
             Object.assign(options.filePaths, {
-              file_label_ind: fileLabelInd
+              fileLabel_ind: fileLabelInd
             });
           }
         } else if (fileProto && labels) {
@@ -144,7 +148,7 @@ var addDetectorApi = function addDetectorApi(matroid) {
 
 
           Object.assign(options.filePaths, {
-            file_proto: fileProto
+            fileProto: fileProto
           });
           Object.assign(options.data, {
             labels: labels,

--- a/dist/src/detectors.js
+++ b/dist/src/detectors.js
@@ -169,7 +169,7 @@ var addDetectorApi = function addDetectorApi(matroid) {
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Detectors-PostDetectorsDetector_idRedo
-  matroid.redoDetector = function (detectorId) {
+  matroid.redoDetector = function (detectorId, feedbackOnly) {
     var _this6 = this;
 
     /*
@@ -180,7 +180,8 @@ var addDetectorApi = function addDetectorApi(matroid) {
 
       var options = {
         action: 'redoDetector',
-        uriParams: { ':key': detectorId }
+        uriParams: { ':key': detectorId },
+        data: { feedbackOnly: feedbackOnly }
       };
 
       _this6._genericRequest(options, resolve, reject);

--- a/dist/src/detectors.js
+++ b/dist/src/detectors.js
@@ -2,8 +2,10 @@
 
 var addDetectorApi = function addDetectorApi(matroid) {
   // https://www.matroid.com/docs/api/index.html#api-Detectors-PostDetectors
-  matroid.createDetector = function (zipFile, name, detectorType, configs) {
+  matroid.createDetector = function (zipFile, name, detectorType) {
     var _this = this;
+
+    var configs = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
 
     /*
     Creates detector asynchronously (turn processing to true) Note: calling this API creates a pending detector, and you can update this detector with more images by calling this API with detector_id; however, creating more than one pending detector is not allowed, so you need to finalize or delete your existing pending detector before creating a new one.
@@ -22,9 +24,7 @@ var addDetectorApi = function addDetectorApi(matroid) {
         filePaths: zipFile
       };
 
-      if (configs && configs.detectorId) {
-        options.data.detectorId = configs.detectorId;
-      }
+      Object.assign(options.data, configs);
 
       _this._genericRequest(options, resolve, reject);
     });
@@ -69,14 +69,14 @@ var addDetectorApi = function addDetectorApi(matroid) {
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Detectors-GetDetectorsDetector_id
-  matroid.getDetectorInfo = function (detectorId) {
+  matroid.detectorInfo = function (detectorId) {
     var _this4 = this;
 
     return new Promise(function (resolve, reject) {
       _this4._checkRequiredParams({ detectorId: detectorId });
 
       var options = {
-        action: 'getDetectorInfo',
+        action: 'detectorInfo',
         uriParams: { ':key': detectorId }
       };
 

--- a/dist/src/helpers.js
+++ b/dist/src/helpers.js
@@ -32,10 +32,11 @@ var addEndPoints = function addEndPoints(matroid) {
     createDetector: matroid._makeEndpoint('POST', 'detectors'),
     deleteDetector: matroid._makeEndpoint('DELETE', 'detectors/:key'),
     trainDetector: matroid._makeEndpoint('POST', 'detectors/:key/finalize'),
-    detectorInfo: matroid._makeEndpoint('GET', 'detectors/:key'),
+    getDetectorInfo: matroid._makeEndpoint('GET', 'detectors/:key'),
     importDetector: matroid._makeEndpoint('POST', 'detectors/upload'),
     redoDetector: matroid._makeEndpoint('POST', 'detectors/:key/redo'),
     searchDetectors: matroid._makeEndpoint('GET', 'detectors/search'),
+    listDetectors: matroid._makeEndpoint('GET', 'detectors'),
 
     // images
     classifyImage: matroid._makeEndpoint('POST', 'detectors/:key/classify_image'),
@@ -54,7 +55,7 @@ var addEndPoints = function addEndPoints(matroid) {
     getVideoResults: matroid._makeEndpoint('GET', 'videos/:key'),
 
     // streams
-    createStream: matroid._makeEndpoint('POST', 'streams'),
+    registerStream: matroid._makeEndpoint('POST', 'streams'),
     deleteMonitoring: matroid._makeEndpoint('DELETE', 'monitorings/:key'),
     deleteStream: matroid._makeEndpoint('DELETE', 'streams/:key'),
     getMonitoringResult: matroid._makeEndpoint('GET', 'monitorings/:key'),

--- a/dist/src/helpers.js
+++ b/dist/src/helpers.js
@@ -14,7 +14,7 @@ var addEndPoints = function addEndPoints(matroid) {
   matroid.endpoints = {
     // accounts
     token: matroid._makeEndpoint('POST', 'oauth/token'),
-    accountInfo: matroid._makeEndpoint('GET', 'account'),
+    getAccountInfo: matroid._makeEndpoint('GET', 'account'),
 
     // collections
     createCollectionIndex: matroid._makeEndpoint('POST', 'collections/:key/collection-tasks'),
@@ -55,7 +55,7 @@ var addEndPoints = function addEndPoints(matroid) {
     getVideoResults: matroid._makeEndpoint('GET', 'videos/:key'),
 
     // streams
-    registerStream: matroid._makeEndpoint('POST', 'streams'),
+    createStream: matroid._makeEndpoint('POST', 'streams'),
     deleteMonitoring: matroid._makeEndpoint('DELETE', 'monitorings/:key'),
     deleteStream: matroid._makeEndpoint('DELETE', 'streams/:key'),
     getMonitoringResult: matroid._makeEndpoint('GET', 'monitorings/:key'),

--- a/dist/src/helpers.js
+++ b/dist/src/helpers.js
@@ -32,7 +32,7 @@ var addEndPoints = function addEndPoints(matroid) {
     createDetector: matroid._makeEndpoint('POST', 'detectors'),
     deleteDetector: matroid._makeEndpoint('DELETE', 'detectors/:key'),
     trainDetector: matroid._makeEndpoint('POST', 'detectors/:key/finalize'),
-    getDetectorInfo: matroid._makeEndpoint('GET', 'detectors/:key'),
+    detectorInfo: matroid._makeEndpoint('GET', 'detectors/:key'),
     importDetector: matroid._makeEndpoint('POST', 'detectors/upload'),
     redoDetector: matroid._makeEndpoint('POST', 'detectors/:key/redo'),
     searchDetectors: matroid._makeEndpoint('GET', 'detectors/search'),

--- a/dist/src/helpers.js
+++ b/dist/src/helpers.js
@@ -14,7 +14,7 @@ var addEndPoints = function addEndPoints(matroid) {
   matroid.endpoints = {
     // accounts
     token: matroid._makeEndpoint('POST', 'oauth/token'),
-    getAccountInfo: matroid._makeEndpoint('GET', 'account'),
+    accountInfo: matroid._makeEndpoint('GET', 'account'),
 
     // collections
     createCollectionIndex: matroid._makeEndpoint('POST', 'collections/:key/collection-tasks'),

--- a/dist/src/helpers.js
+++ b/dist/src/helpers.js
@@ -31,7 +31,7 @@ var addEndPoints = function addEndPoints(matroid) {
     // detectors
     createDetector: matroid._makeEndpoint('POST', 'detectors'),
     deleteDetector: matroid._makeEndpoint('DELETE', 'detectors/:key'),
-    finalizeDetector: matroid._makeEndpoint('POST', 'detectors/:key/finalize'),
+    trainDetector: matroid._makeEndpoint('POST', 'detectors/:key/finalize'),
     getDetectorInfo: matroid._makeEndpoint('GET', 'detectors/:key'),
     importDetector: matroid._makeEndpoint('POST', 'detectors/upload'),
     redoDetector: matroid._makeEndpoint('POST', 'detectors/:key/redo'),

--- a/dist/src/images.js
+++ b/dist/src/images.js
@@ -5,8 +5,7 @@ var addImagesApi = function addImagesApi(matroid) {
   matroid.classifyImage = function (detectorId, image) {
     var _this = this;
 
-    var configs =
-      arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+    var configs = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
     /*
     Expected image format: { url: 'https://www.matroid.com/logo.png'} OR { file: ['/home/user/image.jpg', '/home/user/other_image.png'] }
@@ -20,12 +19,16 @@ var addImagesApi = function addImagesApi(matroid) {
       var options = {
         action: 'classifyImage',
         uriParams: { ':key': detectorId },
-        data: {},
+        data: {}
       };
 
       if (image.file) options.filePaths = image.file;
       if (image.url) {
-        Object.assign(options.data, { url: image.url });
+        if (Array.isArray(image.url)) {
+          Object.assign(options.data, { urls: image.url });
+        } else {
+          Object.assign(options.data, { url: image.url });
+        }
       }
 
       Object.assign(options.data, configs);
@@ -38,28 +41,25 @@ var addImagesApi = function addImagesApi(matroid) {
   matroid.localizeImage = function (localizer, localizerLabel) {
     var _this2 = this;
 
-    var configs =
-      arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+    var configs = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
     /*
     Note: this API is very similar to Images/Classify; however, it can be used to update bounding boxes of existing training images by supplying update=true, labelId, and one of imageId or imageIds, and it has access to the internal face localizer (localizer="DEFAULT_FACE" and localizerLabel="face"). After receiving the results, perform the actual update with the results using Labels/UpdateAnnotations
     */
     return new Promise(function (resolve, reject) {
-      _this2._checkRequiredParams({
-        localizer: localizer,
-        localizerLabel: localizerLabel,
-      });
+      _this2._checkRequiredParams({ localizer: localizer, localizerLabel: localizerLabel });
 
       var update = configs.update;
 
+
       var options = {
         action: 'localizeImage',
-        data: { localizer: localizer, localizerLabel: localizerLabel },
+        data: { localizer: localizer, localizerLabel: localizerLabel }
       };
 
       if (!update) {
         var file = configs.file,
-          url = configs.url;
+            url = configs.url;
 
         _this2._validateImageObj({ file: file, url: url });
         _this2._checkImageSize(file);
@@ -74,13 +74,12 @@ var addImagesApi = function addImagesApi(matroid) {
         }
       } else {
         var labelId = configs.labelId,
-          imageId = configs.imageId,
-          imageIds = configs.imageIds;
+            imageId = configs.imageId,
+            imageIds = configs.imageIds;
 
-        if (!labelId || (!imageId && !imageIds)) {
-          throw new Error(
-            'Please provide labelId and one of imageId/imageIds when setting update to true'
-          );
+
+        if (!labelId || !imageId && !imageIds) {
+          throw new Error('Please provide labelId and one of imageId/imageIds when setting update to true');
         }
       }
 

--- a/dist/src/images.js
+++ b/dist/src/images.js
@@ -8,7 +8,7 @@ var addImagesApi = function addImagesApi(matroid) {
     var configs = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
     /*
-    Expected image format: { url: 'https://www.matroid.com/logo.png'} OR { file: ['/home/user/image.jpg', '/home/user/other_image.png'] }
+    Classify one or more images using a detector. Expected image format: { url: 'https://www.matroid.com/logo.png'} OR { file: ['/home/user/image.jpg', '/home/user/other_image.png'] }.
     */
     return new Promise(function (resolve, reject) {
       _this._checkRequiredParams({ detectorId: detectorId });
@@ -24,11 +24,7 @@ var addImagesApi = function addImagesApi(matroid) {
 
       if (image.file) options.filePaths = image.file;
       if (image.url) {
-        if (Array.isArray(image.url)) {
-          Object.assign(options.data, { urls: image.url });
-        } else {
-          Object.assign(options.data, { url: image.url });
-        }
+        Object.assign(options.data, { url: image.url });
       }
 
       Object.assign(options.data, configs);
@@ -44,7 +40,7 @@ var addImagesApi = function addImagesApi(matroid) {
     var configs = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
     /*
-    Note: this API is very similar to Images/Classify; however, it can be used to update bounding boxes of existing training images by supplying update=true, labelId, and one of imageId or imageIds, and it has access to the internal face localizer (localizer="DEFAULT_FACE" and localizerLabel="face"). After receiving the results, perform the actual update with the results using Labels/UpdateAnnotations
+    This API is very similar to [Images/Classify](#api-Images-Classify). However, it can be used to update bounding boxes of existing training images by supplying `update=true`, `labelId`, and one of `imageId` or `imageIds`. It also has access to the internal face localizer (`localizer="DEFAULT_FACE"` and `localizerLabel="face"`). After receiving the results, perform the actual update using [Labels/Update Annotations](#api-Labels-UpdateAnnotations).
     */
     return new Promise(function (resolve, reject) {
       _this2._checkRequiredParams({ localizer: localizer, localizerLabel: localizerLabel });

--- a/dist/src/labels.js
+++ b/dist/src/labels.js
@@ -69,7 +69,7 @@ var addLabelsApi = function addLabelsApi(matroid) {
 
 
       if (!detectorId && !labelIds && !imageId) {
-        throw new Error('Please pass in one of the ids: detectorId, labelIds, or imageId');
+        throw new Error('Please pass in one of the following IDs: detectorId, labelIds, or imageId');
       }
 
       var options = {

--- a/dist/src/labels.js
+++ b/dist/src/labels.js
@@ -21,7 +21,7 @@ var addLabelsApi = function addLabelsApi(matroid) {
       };
 
       _this._checkImageSize(imageFiles);
-      options.filePaths = { image_files: imageFiles };
+      options.filePaths = { imageFiles: imageFiles };
 
       var processedConfigs = configs;
       if (processedConfigs.bboxes) {
@@ -75,9 +75,9 @@ var addLabelsApi = function addLabelsApi(matroid) {
       var options = {
         action: 'getAnnotations',
         data: {
-          detector_id: detectorId,
-          label_ids: labelIds,
-          image_id: imageId
+          detectorId: detectorId,
+          labelIds: labelIds,
+          imageId: imageId
         }
       };
 
@@ -144,7 +144,7 @@ var addLabelsApi = function addLabelsApi(matroid) {
         data: {}
       };
 
-      options.filePaths = { image_files: imageFiles };
+      options.filePaths = { imageFiles: imageFiles };
 
       var processedConfigs = configs;
       if (processedConfigs.bboxes) {

--- a/dist/src/streams.js
+++ b/dist/src/streams.js
@@ -2,7 +2,7 @@
 
 var addStreamsApi = function addStreamsApi(matroid) {
   // https://www.matroid.com/docs/api/index.html#api-Streams-PostStreams
-  matroid.registerStream = function (url, name) {
+  matroid.createStream = matroid.registerStream = function (url, name) {
     var _this = this;
 
     var configs = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
@@ -15,7 +15,7 @@ var addStreamsApi = function addStreamsApi(matroid) {
       _this._checkRequiredParams({ url: url, name: name });
 
       var options = {
-        action: 'registerStream',
+        action: 'createStream',
         data: { name: name, url: url }
       };
 

--- a/dist/src/streams.js
+++ b/dist/src/streams.js
@@ -2,7 +2,7 @@
 
 var addStreamsApi = function addStreamsApi(matroid) {
   // https://www.matroid.com/docs/api/index.html#api-Streams-PostStreams
-  matroid.createStream = function (url, name) {
+  matroid.registerStream = function (url, name) {
     var _this = this;
 
     var configs = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
@@ -15,7 +15,7 @@ var addStreamsApi = function addStreamsApi(matroid) {
       _this._checkRequiredParams({ url: url, name: name });
 
       var options = {
-        action: 'createStream',
+        action: 'registerStream',
         data: { name: name, url: url }
       };
 
@@ -112,16 +112,16 @@ var addStreamsApi = function addStreamsApi(matroid) {
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Streams-GetMonitoringsQuery
-  matroid.monitorStream = function (streamId, detectorId, thresholds) {
+  matroid.monitorStream = function (streamId, detectorId) {
     var _this6 = this;
 
-    var configs = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+    var configs = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
     /*
-    - endpoint, startTime, endTime, taskName, notificationTimezone, minEmailInterval, sendEmailNotifications, regionEnabled, regionCoords, regionNegativeCoords, monitoringHours, and colors are the parameters passed in the configs object
+    - thresholds, endpoint, startTime, endTime, taskName, notificationTimezone, minEmailInterval, sendEmailNotifications, regionEnabled, regionCoords, regionNegativeCoords, monitoringHours, and colors are the parameters passed in the configs object
     */
     return new Promise(function (resolve, reject) {
-      _this6._checkRequiredParams({ streamId: streamId, detectorId: detectorId, thresholds: thresholds });
+      _this6._checkRequiredParams({ streamId: streamId, detectorId: detectorId });
 
       var options = {
         action: 'monitorStream',
@@ -132,8 +132,12 @@ var addStreamsApi = function addStreamsApi(matroid) {
         data: {}
       };
 
-      Object.assign(options.data, { thresholds: JSON.stringify(thresholds) });
-      Object.assign(options.data, configs);
+      var processedConfigs = configs;
+      if (processedConfigs.thresholds) {
+        processedConfigs.thresholds = JSON.stringify(processedConfigs.thresholds);
+      }
+
+      Object.assign(options.data, processedConfigs);
 
       _this6._genericRequest(options, resolve, reject);
     });

--- a/dist/src/streams.js
+++ b/dist/src/streams.js
@@ -5,8 +5,11 @@ var addStreamsApi = function addStreamsApi(matroid) {
   matroid.createStream = function (url, name) {
     var _this = this;
 
+    var configs = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
     /*
-    Create a stream of a online video url
+    - Create a stream of a online video url
+    - detectionFps, recordingEnabled, and retentionEnabled are the three parameters passed in the configs object
     */
     return new Promise(function (resolve, reject) {
       _this._checkRequiredParams({ url: url, name: name });
@@ -15,6 +18,8 @@ var addStreamsApi = function addStreamsApi(matroid) {
         action: 'createStream',
         data: { name: name, url: url }
       };
+
+      Object.assign(options.data, configs);
 
       _this._genericRequest(options, resolve, reject);
     });
@@ -65,6 +70,9 @@ var addStreamsApi = function addStreamsApi(matroid) {
 
     var configs = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
+    /*
+    - format and statusOnly are parameters passed in the configs object
+    */
     return new Promise(function (resolve, reject) {
       _this4._checkRequiredParams({ monitoringId: monitoringId });
 
@@ -109,6 +117,9 @@ var addStreamsApi = function addStreamsApi(matroid) {
 
     var configs = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
 
+    /*
+    - endpoint, startTime, endTime, taskName, notificationTimezone, minEmailInterval, sendEmailNotifications, regionEnabled, regionCoords, regionNegativeCoords, monitoringHours, and colors are the parameters passed in the configs object
+    */
     return new Promise(function (resolve, reject) {
       _this6._checkRequiredParams({ streamId: streamId, detectorId: detectorId, thresholds: thresholds });
 
@@ -134,6 +145,9 @@ var addStreamsApi = function addStreamsApi(matroid) {
 
     var configs = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
+    /*
+    - streamId, monitoringId, detectorId, name, startTime, endTime, and state are the parameters passed in the configs object
+    */
     return new Promise(function (resolve, reject) {
       var options = {
         action: 'searchMonitorings',
@@ -153,6 +167,9 @@ var addStreamsApi = function addStreamsApi(matroid) {
 
     var configs = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
+    /*
+    - streamId, name, and permission are the three parameters passed in the configs object
+    */
     return new Promise(function (resolve, reject) {
       var options = {
         action: 'searchStreams',

--- a/dist/src/videos.js
+++ b/dist/src/videos.js
@@ -40,14 +40,14 @@ var addVideosApi = function addVideosApi(matroid) {
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Videos-GetVideosVideo_idQuery
-  matroid.getVideoResults = function (videoId) {
+  matroid.getVideoResults = function (videoId, threshold, format) {
     var _this2 = this;
 
-    var configs = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var configs = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
 
     /*
     - Get video classification results
-    - format, annotations, and threshold are the three parameters passed in the configs object
+    - annotations is the parameter passed in the configs object
     */
     return new Promise(function (resolve, reject) {
       _this2._checkRequiredParams({ videoId: videoId });
@@ -55,11 +55,11 @@ var addVideosApi = function addVideosApi(matroid) {
       var options = {
         action: 'getVideoResults',
         uriParams: { ':key': videoId },
-        data: {}
+        data: { threshold: threshold, format: format }
       };
 
       Object.assign(options.data, configs);
-      if (configs.format === 'csv') options.shouldNotParse = true;
+      if (format === 'csv') options.shouldNotParse = true;
 
       _this2._genericRequest(options, resolve, reject);
     });

--- a/dist/src/videos.js
+++ b/dist/src/videos.js
@@ -5,8 +5,11 @@ var addVideosApi = function addVideosApi(matroid) {
   matroid.classifyVideo = function (detectorId, video) {
     var _this = this;
 
+    var configs = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+
     /*
-    Expected video format: { url: 'https://online-video-url'} OR { file: '/home/user/video.mp4'}
+    - Expected video format: { url: 'https://online-video-url'} OR { file: '/home/user/video.mp4'}
+    - videoId, fps, and annotationThresholds are the three parameters passed in the configs object
     */
     return new Promise(function (resolve, reject) {
       _this._checkRequiredParams({ detectorId: detectorId, video: video });
@@ -30,6 +33,7 @@ var addVideosApi = function addVideosApi(matroid) {
 
       if (video.file) options.filePaths = video.file;
       if (video.url) options.data = { url: video.url };
+      Object.assign(options.data, configs);
 
       _this._genericRequest(options, resolve, reject);
     });
@@ -42,7 +46,8 @@ var addVideosApi = function addVideosApi(matroid) {
     var configs = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
     /*
-    Get video classification results
+    - Get video classification results
+    - format, annotations, and threshold are the three parameters passed in the configs object
     */
     return new Promise(function (resolve, reject) {
       _this2._checkRequiredParams({ videoId: videoId });

--- a/lib/src/accounts.js
+++ b/lib/src/accounts.js
@@ -36,10 +36,10 @@ const addAccountsApi = (matroid) => {
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Accounts-GetAccount
-  matroid.getAccountInfo = function () {
+  matroid.accountInfo = function () {
     return new Promise((resolve, reject) => {
       let options = {
-        action: 'getAccountInfo',
+        action: 'accountInfo',
       };
 
       this._genericRequest(options, resolve, reject);

--- a/lib/src/accounts.js
+++ b/lib/src/accounts.js
@@ -36,10 +36,11 @@ const addAccountsApi = (matroid) => {
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Accounts-GetAccount
-  matroid.accountInfo = function () {
+  // Formerly called accountInfo (now deprecated), use getAccountInfo
+  matroid.getAccountInfo = matroid.accountInfo = function () {
     return new Promise((resolve, reject) => {
       let options = {
-        action: 'accountInfo',
+        action: 'getAccountInfo',
       };
 
       this._genericRequest(options, resolve, reject);

--- a/lib/src/collections.js
+++ b/lib/src/collections.js
@@ -6,7 +6,7 @@ const addCollectionsApi = (matroid) => {
     fileTypes
   ) {
     /*
-    Create an index on a collection with a detector
+    Creates an index on a collection with a detector.
     */
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ collectionId, detectorId, fileTypes });
@@ -22,9 +22,9 @@ const addCollectionsApi = (matroid) => {
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Collections-PostCollections
-  matroid.createCollection = function (name, url, sourceType) {
+  matroid.createCollection = function (name, url, sourceType, configs = {}) {
     /*
-    Creates a new collection from a web or S3 url. Automatically kick off default indexes
+    Creates a new collection from a web or S3 url.
     */
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ name, url, sourceType });
@@ -34,6 +34,11 @@ const addCollectionsApi = (matroid) => {
         data: { name, url, sourceType },
       };
 
+      const { indexWithDefault } = configs;
+      if (indexWithDefault) {
+        options.data.indexWithDefault = indexWithDefault;
+      }
+
       this._genericRequest(options, resolve, reject);
     });
   };
@@ -41,7 +46,7 @@ const addCollectionsApi = (matroid) => {
   // https://www.matroid.com/docs/api/index.html#api-Collections-DeleteCollectionTasksTaskid
   matroid.deleteCollectionIndex = function (collectionTaskId) {
     /*
-    Deletes a completed collection manager task
+    Deletes a completed collection task.
     */
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ collectionTaskId });
@@ -58,7 +63,7 @@ const addCollectionsApi = (matroid) => {
   // https://www.matroid.com/docs/api/index.html#api-Collections-DeleteCollectionsCollectionid
   matroid.deleteCollection = function (collectionId) {
     /*
-    Deletes a collection with no active indexing tasks
+    Deletes a collection with no active indexing tasks.
     */
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ collectionId });
@@ -75,7 +80,7 @@ const addCollectionsApi = (matroid) => {
   // https://www.matroid.com/docs/api/index.html#api-Collections-GetCollectionTasksTaskid
   matroid.getCollectionTask = function (collectionTaskId) {
     /*
-    Creates a new collection from a web or S3 url
+    Retrieves information about a specific collection task.
     */
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ collectionTaskId });
@@ -92,7 +97,7 @@ const addCollectionsApi = (matroid) => {
   // https://www.matroid.com/docs/api/index.html#api-Collections-GetCollectionsCollectionid
   matroid.getCollection = function (collectionId) {
     /*
-    Get information about a specific collection
+    Retrieves information about a specific collection.
     */
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ collectionId });
@@ -112,7 +117,7 @@ const addCollectionsApi = (matroid) => {
     includeCollectionInfo
   ) {
     /*
-    Kills an active collection indexing task
+    Kills an active collection indexing task.
     */
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ collectionTaskId });
@@ -129,7 +134,7 @@ const addCollectionsApi = (matroid) => {
   // https://www.matroid.com/docs/api/index.html#api-Collections-PostApiVersionCollectionTasksTaskidScoresQuery
   matroid.queryCollectionByScores = function (taskId, thresholds, numResults) {
     /*
-    Query against a collection index using a set of labels and scores as a query
+    Queries against a collection index using a set of labels and scores.
     */
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ taskId, thresholds, numResults });
@@ -147,7 +152,7 @@ const addCollectionsApi = (matroid) => {
   // https://www.matroid.com/docs/api/index.html#api-Collections-PostApiCollectionTasksTaskidImageQuery
   matroid.queryCollectionByImage = function (taskId, image, configs = {}) {
     /*
-    Query against a collection index (CollectionManagerTask) using an image as key
+    Queries against a collection index using an image.
     */
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ taskId, image });
@@ -168,12 +173,15 @@ const addCollectionsApi = (matroid) => {
         Object.assign(options.data, { url: image.url });
       }
 
-      const { numResults, boundingBox } = configs;
+      const { numResults, boundingBox, shouldIndicateDuplicates } = configs;
       if (numResults) {
         options.data.numResults = numResults;
       }
       if (boundingBox) {
         options.data.boundingBox = JSON.stringify(boundingBox);
+      }
+      if (shouldIndicateDuplicates) {
+        options.data.shouldIndicateDuplicates = shouldIndicateDuplicates;
       }
 
       this._genericRequest(options, resolve, reject);

--- a/lib/src/collections.js
+++ b/lib/src/collections.js
@@ -142,7 +142,7 @@ const addCollectionsApi = (matroid) => {
       let options = {
         action: 'queryCollectionByScores',
         uriParams: { ':key': taskId },
-        data: { numResults },
+        data: { thresholds },
       };
       Object.assign(options.data, configs);
 

--- a/lib/src/collections.js
+++ b/lib/src/collections.js
@@ -132,18 +132,19 @@ const addCollectionsApi = (matroid) => {
     });
   };
   // https://www.matroid.com/docs/api/index.html#api-Collections-PostApiVersionCollectionTasksTaskidScoresQuery
-  matroid.queryCollectionByScores = function (taskId, thresholds, numResults) {
+  matroid.queryCollectionByScores = function (taskId, thresholds, configs) {
     /*
     Queries against a collection index using a set of labels and scores.
     */
     return new Promise((resolve, reject) => {
-      this._checkRequiredParams({ taskId, thresholds, numResults });
+      this._checkRequiredParams({ taskId, thresholds });
 
       let options = {
         action: 'queryCollectionByScores',
         uriParams: { ':key': taskId },
-        data: { thresholds, numResults },
+        data: { numResults },
       };
+      Object.assign(options.data, configs);
 
       this._genericRequest(options, resolve, reject);
     });

--- a/lib/src/detectors.js
+++ b/lib/src/detectors.js
@@ -154,7 +154,7 @@ const addDetectorApi = (matroid) => {
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Detectors-PostDetectorsDetector_idRedo
-  matroid.redoDetector = function (detectorId) {
+  matroid.redoDetector = function (detectorId, feedbackOnly) {
     /*
     A deep copy of the trained detector with different detector_id will be made
     */
@@ -164,6 +164,7 @@ const addDetectorApi = (matroid) => {
       let options = {
         action: 'redoDetector',
         uriParams: { ':key': detectorId },
+        data: { feedbackOnly },
       };
 
       this._genericRequest(options, resolve, reject);

--- a/lib/src/detectors.js
+++ b/lib/src/detectors.js
@@ -23,7 +23,7 @@ const addDetectorApi = (matroid) => {
         filePaths: zipFile,
       };
 
-      if (configs.detectorId) {
+      if (configs && configs.detectorId) {
         options.data.detectorId = configs.detectorId;
       }
 
@@ -49,7 +49,7 @@ const addDetectorApi = (matroid) => {
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Detectors-PostDetectorsDetector_idFinalize
-  matroid.finalizeDetector = function (detectorId) {
+  matroid.trainDetector = function (detectorId) {
     /*
     Requires processing=false. Starts training asynchronously (turn processing to true)
     */
@@ -57,7 +57,7 @@ const addDetectorApi = (matroid) => {
       this._checkRequiredParams({ detectorId });
 
       let options = {
-        action: 'finalizeDetector',
+        action: 'trainDetector',
         uriParams: { ':key': detectorId },
       };
 
@@ -145,7 +145,7 @@ const addDetectorApi = (matroid) => {
             Object.assign(options.data, { label_inds: labelInds });
           }
         } else {
-          throw new Error('Invalid paramter combination');
+          throw new Error('Invalid parameter combination');
         }
       }
 

--- a/lib/src/detectors.js
+++ b/lib/src/detectors.js
@@ -1,6 +1,6 @@
 const addDetectorApi = (matroid) => {
   // https://www.matroid.com/docs/api/index.html#api-Detectors-PostDetectors
-  matroid.createDetector = function (zipFile, name, detectorType, configs) {
+  matroid.createDetector = function (zipFile, name, detectorType, configs = {}) {
     /*
     Creates detector asynchronously (turn processing to true) Note: calling this API creates a pending detector, and you can update this detector with more images by calling this API with detector_id; however, creating more than one pending detector is not allowed, so you need to finalize or delete your existing pending detector before creating a new one.
 
@@ -23,9 +23,7 @@ const addDetectorApi = (matroid) => {
         filePaths: zipFile,
       };
 
-      if (configs && configs.detectorId) {
-        options.data.detectorId = configs.detectorId;
-      }
+      Object.assign(options.data, configs);
 
       this._genericRequest(options, resolve, reject);
     });
@@ -66,12 +64,12 @@ const addDetectorApi = (matroid) => {
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Detectors-GetDetectorsDetector_id
-  matroid.getDetectorInfo = function (detectorId) {
+  matroid.detectorInfo = function (detectorId) {
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ detectorId });
 
       let options = {
-        action: 'getDetectorInfo',
+        action: 'detectorInfo',
         uriParams: { ':key': detectorId },
       };
 

--- a/lib/src/detectors.js
+++ b/lib/src/detectors.js
@@ -64,12 +64,13 @@ const addDetectorApi = (matroid) => {
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Detectors-GetDetectorsDetector_id
-  matroid.detectorInfo = function (detectorId) {
+  // Formerly called detectorInfo (now deprecated), use getDetectorInfo
+  matroid.getDetectorInfo = matroid.detectorInfo = function (detectorId) {
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ detectorId });
 
       let options = {
-        action: 'detectorInfo',
+        action: 'getDetectorInfo',
         uriParams: { ':key': detectorId },
       };
 
@@ -181,6 +182,20 @@ const addDetectorApi = (matroid) => {
       };
 
       Object.assign(options.data, configs);
+
+      this._genericRequest(options, resolve, reject);
+    });
+  };
+
+  // DEPRECATED - use searchDetectors now
+  matroid.listDetectors = function () {
+    /*
+    Lists all detectors that are public or owned by the user.
+    */
+    return new Promise((resolve, reject) => {
+      let options = {
+        action: 'listDetectors',
+      };
 
       this._genericRequest(options, resolve, reject);
     });

--- a/lib/src/helpers.js
+++ b/lib/src/helpers.js
@@ -44,10 +44,11 @@ const addEndPoints = matroid => {
     createDetector: matroid._makeEndpoint('POST', 'detectors'),
     deleteDetector: matroid._makeEndpoint('DELETE', 'detectors/:key'),
     trainDetector: matroid._makeEndpoint('POST', 'detectors/:key/finalize'),
-    detectorInfo: matroid._makeEndpoint('GET', 'detectors/:key'),
+    getDetectorInfo: matroid._makeEndpoint('GET', 'detectors/:key'),
     importDetector: matroid._makeEndpoint('POST', 'detectors/upload'),
     redoDetector: matroid._makeEndpoint('POST', 'detectors/:key/redo'),
     searchDetectors: matroid._makeEndpoint('GET', 'detectors/search'),
+    listDetectors: matroid._makeEndpoint('GET', 'detectors'),
 
     // images
     classifyImage: matroid._makeEndpoint(
@@ -87,7 +88,7 @@ const addEndPoints = matroid => {
     getVideoResults: matroid._makeEndpoint('GET', 'videos/:key'),
 
     // streams
-    createStream: matroid._makeEndpoint('POST', 'streams'),
+    registerStream: matroid._makeEndpoint('POST', 'streams'),
     deleteMonitoring: matroid._makeEndpoint('DELETE', 'monitorings/:key'),
     deleteStream: matroid._makeEndpoint('DELETE', 'streams/:key'),
     getMonitoringResult: matroid._makeEndpoint('GET', 'monitorings/:key'),

--- a/lib/src/helpers.js
+++ b/lib/src/helpers.js
@@ -8,7 +8,7 @@ const addEndPoints = matroid => {
   matroid.endpoints = {
     // accounts
     token: matroid._makeEndpoint('POST', 'oauth/token'),
-    getAccountInfo: matroid._makeEndpoint('GET', 'account'),
+    accountInfo: matroid._makeEndpoint('GET', 'account'),
 
     // collections
     createCollectionIndex: matroid._makeEndpoint(

--- a/lib/src/helpers.js
+++ b/lib/src/helpers.js
@@ -44,7 +44,7 @@ const addEndPoints = matroid => {
     createDetector: matroid._makeEndpoint('POST', 'detectors'),
     deleteDetector: matroid._makeEndpoint('DELETE', 'detectors/:key'),
     trainDetector: matroid._makeEndpoint('POST', 'detectors/:key/finalize'),
-    getDetectorInfo: matroid._makeEndpoint('GET', 'detectors/:key'),
+    detectorInfo: matroid._makeEndpoint('GET', 'detectors/:key'),
     importDetector: matroid._makeEndpoint('POST', 'detectors/upload'),
     redoDetector: matroid._makeEndpoint('POST', 'detectors/:key/redo'),
     searchDetectors: matroid._makeEndpoint('GET', 'detectors/search'),

--- a/lib/src/helpers.js
+++ b/lib/src/helpers.js
@@ -8,7 +8,7 @@ const addEndPoints = matroid => {
   matroid.endpoints = {
     // accounts
     token: matroid._makeEndpoint('POST', 'oauth/token'),
-    accountInfo: matroid._makeEndpoint('GET', 'account'),
+    getAccountInfo: matroid._makeEndpoint('GET', 'account'),
 
     // collections
     createCollectionIndex: matroid._makeEndpoint(
@@ -88,7 +88,7 @@ const addEndPoints = matroid => {
     getVideoResults: matroid._makeEndpoint('GET', 'videos/:key'),
 
     // streams
-    registerStream: matroid._makeEndpoint('POST', 'streams'),
+    createStream: matroid._makeEndpoint('POST', 'streams'),
     deleteMonitoring: matroid._makeEndpoint('DELETE', 'monitorings/:key'),
     deleteStream: matroid._makeEndpoint('DELETE', 'streams/:key'),
     getMonitoringResult: matroid._makeEndpoint('GET', 'monitorings/:key'),

--- a/lib/src/helpers.js
+++ b/lib/src/helpers.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const mime = require('mime-types');
 const util = require('util');
-this is a test
+
 const addEndPoints = matroid => {
   matroid.endpoints = {
     // accounts

--- a/lib/src/helpers.js
+++ b/lib/src/helpers.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const mime = require('mime-types');
 const util = require('util');
-
+this is a test
 const addEndPoints = matroid => {
   matroid.endpoints = {
     // accounts

--- a/lib/src/helpers.js
+++ b/lib/src/helpers.js
@@ -43,7 +43,7 @@ const addEndPoints = matroid => {
     // detectors
     createDetector: matroid._makeEndpoint('POST', 'detectors'),
     deleteDetector: matroid._makeEndpoint('DELETE', 'detectors/:key'),
-    finalizeDetector: matroid._makeEndpoint('POST', 'detectors/:key/finalize'),
+    trainDetector: matroid._makeEndpoint('POST', 'detectors/:key/finalize'),
     getDetectorInfo: matroid._makeEndpoint('GET', 'detectors/:key'),
     importDetector: matroid._makeEndpoint('POST', 'detectors/upload'),
     redoDetector: matroid._makeEndpoint('POST', 'detectors/:key/redo'),

--- a/lib/src/images.js
+++ b/lib/src/images.js
@@ -2,7 +2,7 @@ const addImagesApi = matroid => {
   // https://www.matroid.com/docs/api/index.html#api-Images-Classify
   matroid.classifyImage = function(detectorId, image, configs = {}) {
     /*
-    Expected image format: { url: 'https://www.matroid.com/logo.png'} OR { file: ['/home/user/image.jpg', '/home/user/other_image.png'] }
+    Classify one or more images using a detector. Expected image format: { url: 'https://www.matroid.com/logo.png'} OR { file: ['/home/user/image.jpg', '/home/user/other_image.png'] }.
     */
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ detectorId });
@@ -18,11 +18,7 @@ const addImagesApi = matroid => {
 
       if (image.file) options.filePaths = image.file;
       if (image.url) {
-        if (Array.isArray(image.url)) {
-          Object.assign(options.data, { urls: image.url });
-        } else {
           Object.assign(options.data, { url: image.url });
-        }
       }
 
       Object.assign(options.data, configs);
@@ -34,7 +30,7 @@ const addImagesApi = matroid => {
   // https://www.matroid.com/docs/api/index.html#api-Images-PostLocalize
   matroid.localizeImage = function(localizer, localizerLabel, configs = {}) {
     /*
-    Note: this API is very similar to Images/Classify; however, it can be used to update bounding boxes of existing training images by supplying update=true, labelId, and one of imageId or imageIds, and it has access to the internal face localizer (localizer="DEFAULT_FACE" and localizerLabel="face"). After receiving the results, perform the actual update with the results using Labels/UpdateAnnotations
+    This API is very similar to [Images/Classify](#api-Images-Classify). However, it can be used to update bounding boxes of existing training images by supplying `update=true`, `labelId`, and one of `imageId` or `imageIds`. It also has access to the internal face localizer (`localizer="DEFAULT_FACE"` and `localizerLabel="face"`). After receiving the results, perform the actual update using [Labels/Update Annotations](#api-Labels-UpdateAnnotations).
     */
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ localizer, localizerLabel });

--- a/lib/src/labels.js
+++ b/lib/src/labels.js
@@ -22,7 +22,7 @@ const addLabelsApi = (matroid) => {
       this._checkImageSize(imageFiles);
       options.filePaths = { imageFiles };
 
-      let processedConfigs = configs;
+      const processedConfigs = configs;
       if (processedConfigs.bboxes) {
         processedConfigs.bboxes = JSON.stringify(processedConfigs.bboxes);
       }
@@ -41,7 +41,7 @@ const addLabelsApi = (matroid) => {
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ detectorId, labelId });
 
-      let options = {
+      const options = {
         action: 'deleteLabel',
         uriParams: { ':detectorId': detectorId, ':labelId': labelId },
       };
@@ -60,11 +60,11 @@ const addLabelsApi = (matroid) => {
 
       if (!detectorId && !labelIds && !imageId) {
         throw new Error(
-          'Please pass in one of the ids: detectorId, labelIds, or imageId'
+          'Please pass in one of the following IDs: detectorId, labelIds, or imageId'
         );
       }
 
-      let options = {
+      const options = {
         action: 'getAnnotations',
         data: {
           detectorId,
@@ -82,7 +82,7 @@ const addLabelsApi = (matroid) => {
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ detectorId, labelId });
 
-      let options = {
+      const options = {
         action: 'getLabelImages',
         uriParams: { ':detectorId': detectorId, ':labelId': labelId },
       };
@@ -104,7 +104,7 @@ const addLabelsApi = (matroid) => {
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ detectorId, labelId, images });
 
-      let options = {
+      const options = {
         action: 'updateAnnotations',
         uriParams: { ':detectorId': detectorId, ':labelId': labelId },
         data: {},
@@ -130,7 +130,7 @@ const addLabelsApi = (matroid) => {
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ detectorId, labelId, imageFiles });
 
-      let options = {
+      const options = {
         action: 'updateLabelWithImages',
         uriParams: { ':detectorId': detectorId, ':labelId': labelId },
         data: {},
@@ -138,7 +138,7 @@ const addLabelsApi = (matroid) => {
 
       options.filePaths = { imageFiles: imageFiles };
 
-      let processedConfigs = configs;
+      const processedConfigs = configs;
       if (processedConfigs.bboxes) {
         processedConfigs.bboxes = JSON.stringify(processedConfigs.bboxes);
       }

--- a/lib/src/streams.js
+++ b/lib/src/streams.js
@@ -1,6 +1,6 @@
 const addStreamsApi = matroid => {
   // https://www.matroid.com/docs/api/index.html#api-Streams-PostStreams
-  matroid.createStream = function(url, name, configs = {}) {
+  matroid.registerStream = function(url, name, configs = {}) {
     /*
     - Create a stream of a online video url
     - detectionFps, recordingEnabled, and retentionEnabled are the three parameters passed in the configs object
@@ -9,7 +9,7 @@ const addStreamsApi = matroid => {
       this._checkRequiredParams({ url, name });
 
       let options = {
-        action: 'createStream',
+        action: 'registerStream',
         data: { name, url }
       };
 
@@ -99,14 +99,13 @@ const addStreamsApi = matroid => {
   matroid.monitorStream = function(
     streamId,
     detectorId,
-    thresholds,
     configs = {}
   ) {
     /*
-    - endpoint, startTime, endTime, taskName, notificationTimezone, minEmailInterval, sendEmailNotifications, regionEnabled, regionCoords, regionNegativeCoords, monitoringHours, and colors are the parameters passed in the configs object
+    - thresholds, endpoint, startTime, endTime, taskName, notificationTimezone, minEmailInterval, sendEmailNotifications, regionEnabled, regionCoords, regionNegativeCoords, monitoringHours, and colors are the parameters passed in the configs object
     */
     return new Promise((resolve, reject) => {
-      this._checkRequiredParams({ streamId, detectorId, thresholds });
+      this._checkRequiredParams({ streamId, detectorId });
 
       let options = {
         action: 'monitorStream',
@@ -117,8 +116,12 @@ const addStreamsApi = matroid => {
         data: {}
       };
 
-      Object.assign(options.data, { thresholds: JSON.stringify(thresholds) });
-      Object.assign(options.data, configs);
+      const processedConfigs = configs;
+      if (processedConfigs.thresholds) {
+        processedConfigs.thresholds = JSON.stringify(processedConfigs.thresholds);
+      }
+
+      Object.assign(options.data, processedConfigs);
 
       this._genericRequest(options, resolve, reject);
     });

--- a/lib/src/streams.js
+++ b/lib/src/streams.js
@@ -1,6 +1,6 @@
 const addStreamsApi = matroid => {
   // https://www.matroid.com/docs/api/index.html#api-Streams-PostStreams
-  matroid.registerStream = function(url, name, configs = {}) {
+  matroid.createStream = matroid.registerStream = function(url, name, configs = {}) {
     /*
     - Create a stream of a online video url
     - detectionFps, recordingEnabled, and retentionEnabled are the three parameters passed in the configs object
@@ -9,7 +9,7 @@ const addStreamsApi = matroid => {
       this._checkRequiredParams({ url, name });
 
       let options = {
-        action: 'registerStream',
+        action: 'createStream',
         data: { name, url }
       };
 

--- a/lib/src/streams.js
+++ b/lib/src/streams.js
@@ -1,8 +1,9 @@
 const addStreamsApi = matroid => {
   // https://www.matroid.com/docs/api/index.html#api-Streams-PostStreams
-  matroid.createStream = function(url, name) {
+  matroid.createStream = function(url, name, configs = {}) {
     /*
-    Create a stream of a online video url
+    - Create a stream of a online video url
+    - detectionFps, recordingEnabled, and retentionEnabled are the three parameters passed in the configs object
     */
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ url, name });
@@ -11,6 +12,8 @@ const addStreamsApi = matroid => {
         action: 'createStream',
         data: { name, url }
       };
+
+      Object.assign(options.data, configs);
 
       this._genericRequest(options, resolve, reject);
     });
@@ -53,6 +56,9 @@ const addStreamsApi = matroid => {
 
   // https://www.matroid.com/docs/api/index.html#api-Streams-GetMonitoringsMonitoring_idQuery
   matroid.getMonitoringResult = function(monitoringId, configs = {}) {
+    /*
+    - format and statusOnly are parameters passed in the configs object
+    */
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ monitoringId });
 
@@ -96,6 +102,9 @@ const addStreamsApi = matroid => {
     thresholds,
     configs = {}
   ) {
+    /*
+    - endpoint, startTime, endTime, taskName, notificationTimezone, minEmailInterval, sendEmailNotifications, regionEnabled, regionCoords, regionNegativeCoords, monitoringHours, and colors are the parameters passed in the configs object
+    */
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ streamId, detectorId, thresholds });
 
@@ -117,6 +126,9 @@ const addStreamsApi = matroid => {
 
   // https://www.matroid.com/docs/api/index.html#api-Streams-PostStreamsStream_idMonitorDetector_id
   matroid.searchMonitorings = function(configs = {}) {
+    /*
+    - streamId, monitoringId, detectorId, name, startTime, endTime, and state are the parameters passed in the configs object
+    */
     return new Promise((resolve, reject) => {
       let options = {
         action: 'searchMonitorings',
@@ -132,6 +144,9 @@ const addStreamsApi = matroid => {
 
   // https://www.matroid.com/docs/api/index.html#api-Streams-GetStreamsQuery
   matroid.searchStreams = function(configs = {}) {
+    /*
+    - streamId, name, and permission are the three parameters passed in the configs object
+    */
     return new Promise((resolve, reject) => {
       let options = {
         action: 'searchStreams',

--- a/lib/src/videos.js
+++ b/lib/src/videos.js
@@ -44,10 +44,10 @@ const addVideosApi = matroid => {
   };
 
   // https://www.matroid.com/docs/api/index.html#api-Videos-GetVideosVideo_idQuery
-  matroid.getVideoResults = function(videoId, configs = {}) {
+  matroid.getVideoResults = function(videoId, threshold, format, configs = {}) {
     /*
     - Get video classification results
-    - format, annotations, and threshold are the three parameters passed in the configs object
+    - annotations is the parameter passed in the configs object
     */
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ videoId });
@@ -55,11 +55,11 @@ const addVideosApi = matroid => {
       let options = {
         action: 'getVideoResults',
         uriParams: { ':key': videoId },
-        data: {}
+        data: { threshold, format }
       };
 
       Object.assign(options.data, configs);
-      if (configs.format === 'csv') options.shouldNotParse = true;
+      if (format === 'csv') options.shouldNotParse = true;
 
       this._genericRequest(options, resolve, reject);
     });

--- a/lib/src/videos.js
+++ b/lib/src/videos.js
@@ -1,8 +1,9 @@
 const addVideosApi = matroid => {
   // https://www.matroid.com/docs/api/index.html#api-Videos-PostDetectorsDetector_idClassify_video
-  matroid.classifyVideo = function(detectorId, video) {
+  matroid.classifyVideo = function(detectorId, video, configs = {}) {
     /*
-    Expected video format: { url: 'https://online-video-url'} OR { file: '/home/user/video.mp4'}
+    - Expected video format: { url: 'https://online-video-url'} OR { file: '/home/user/video.mp4'}
+    - videoId, fps, and annotationThresholds are the three parameters passed in the configs object
     */
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ detectorId, video });
@@ -36,6 +37,7 @@ const addVideosApi = matroid => {
 
       if (video.file) options.filePaths = video.file;
       if (video.url) options.data = { url: video.url };
+      Object.assign(options.data, configs);
 
       this._genericRequest(options, resolve, reject);
     });
@@ -44,7 +46,8 @@ const addVideosApi = matroid => {
   // https://www.matroid.com/docs/api/index.html#api-Videos-GetVideosVideo_idQuery
   matroid.getVideoResults = function(videoId, configs = {}) {
     /*
-    Get video classification results
+    - Get video classification results
+    - format, annotations, and threshold are the three parameters passed in the configs object
     */
     return new Promise((resolve, reject) => {
       this._checkRequiredParams({ videoId });

--- a/test/data.js
+++ b/test/data.js
@@ -1,7 +1,7 @@
 module.exports = {
   INVALID_QUERY_ERR: 'invalid_query_err',
   EVERYDAY_OBJECT_ID: '598e23679fd1a805a5c09275',
-  RANDOM_MONGO_ID: '5d0966ba1eff390eb5d9e2c2',
+  RANDOM_MONGO_ID: '6036ccacba368fbbd2cb20ce',
   DETECTOR_ZIP: `${__dirname}/test-files/detector.zip`,
   DOG_FILE: `${__dirname}/test-files/dog.jpg`,
   CAT_FILE: `${__dirname}/test-files/cat.jpg`,

--- a/test/data.js
+++ b/test/data.js
@@ -10,6 +10,6 @@ module.exports = {
     'https://matroid-web.s3.amazonaws.com/test/python-client/tesla-cat.jpg',
   UPLOAD_PB_FILE: `${__dirname}/test-files/upload-detector.pb`,
   UPLOAD_LABEL_FILE: `${__dirname}/test-files/upload-detector-label.txt`,
-  YOUTUBE_VID_URL: 'https://www.youtube.com/watch?v=nDvh3upNJmA',
+  S3_VID_URL: 'https://m-test-public.s3-us-west-2.amazonaws.com/videos/Multiple+cars+-+5s.mp4',
   S3_BUCKET_URL: 's3://bucket/m-test-public/'
 };

--- a/test/data.js
+++ b/test/data.js
@@ -11,5 +11,6 @@ module.exports = {
   UPLOAD_PB_FILE: `${__dirname}/test-files/upload-detector.pb`,
   UPLOAD_LABEL_FILE: `${__dirname}/test-files/upload-detector-label.txt`,
   S3_VID_URL: 'https://m-test-public.s3-us-west-2.amazonaws.com/videos/Multiple+cars+-+5s.mp4',
+  S3_VID_URL_2: 'https://m-test-public.s3.us-west-2.amazonaws.com/videos/TomCruiseInterview.mp4',
   S3_BUCKET_URL: 's3://bucket/m-test-public/'
 };

--- a/test/test-accounts.js
+++ b/test/test-accounts.js
@@ -19,8 +19,16 @@ describe('Accounts', function() {
     });
   });
 
-  describe('accountInfo', function() {
+  describe('getAccountInfo', function() {
     it('should get account info', async function() {
+      const res = await this.api.getAccountInfo();
+
+      expect(res.account).to.be.an('object');
+      expect(res.account).to.have.property('name');
+      expect(res.account).to.have.property('email');
+    });
+
+    it('should get account info using accountInfo (deprecated for getAccountInfo)', async function () {
       const res = await this.api.accountInfo();
 
       expect(res.account).to.be.an('object');

--- a/test/test-accounts.js
+++ b/test/test-accounts.js
@@ -19,9 +19,9 @@ describe('Accounts', function() {
     });
   });
 
-  describe('getAccountInfo', function() {
+  describe('accountInfo', function() {
     it('should get account info', async function() {
-      const res = await this.api.getAccountInfo();
+      const res = await this.api.accountInfo();
 
       expect(res.account).to.be.an('object');
       expect(res.account).to.have.property('name');

--- a/test/test-detectors.js
+++ b/test/test-detectors.js
@@ -80,15 +80,15 @@ describe('Detectors', function () {
     });
   });
 
-  describe('getDetectorInfo', function () {
+  describe('detectorInfo', function () {
     it('should get detector info', async function () {
-      const res = await this.api.getDetectorInfo(detectorId);
+      const res = await this.api.detectorInfo(detectorId);
 
       expect(res.id).to.equal(detectorId, JSON.stringify(res));
     });
 
     it('should get an error with an invalid detector ID', async function () {
-      const res = await this.api.getDetectorInfo(RANDOM_MONGO_ID);
+      const res = await this.api.detectorInfo(RANDOM_MONGO_ID);
 
       expect(res.code).to.equal(INVALID_QUERY_ERR, JSON.stringify(res));
     });
@@ -196,7 +196,7 @@ async function waitDetectorTraining(api, detectorId) {
   // wait until detector is trained
   printInfo('waiting for detector training');
 
-  let res = await api.getDetectorInfo(detectorId);
+  let res = await api.detectorInfo(detectorId);
   let indicator = '\x1b[2m      .';
   const maxTries = 40;
 
@@ -211,7 +211,7 @@ async function waitDetectorTraining(api, detectorId) {
     }
 
     await sleep(5000);
-    res = await api.getDetectorInfo(detectorId);
+    res = await api.detectorInfo(detectorId);
   }
 
   printInfo('detector is ready.');

--- a/test/test-detectors.js
+++ b/test/test-detectors.js
@@ -178,7 +178,7 @@ describe('Detectors', function () {
     });
   });
 
-  describe('listDetectors', function () {
+  describe('listDetectors (deprecated for searchDetectors)', function () {
     it('should list all detectors', async function () {
       const res = await this.api.listDetectors();
 

--- a/test/test-detectors.js
+++ b/test/test-detectors.js
@@ -80,15 +80,21 @@ describe('Detectors', function () {
     });
   });
 
-  describe('detectorInfo', function () {
+  describe('getDetectorInfo', function () {
     it('should get detector info', async function () {
+      const res = await this.api.getDetectorInfo(detectorId);
+
+      expect(res.id).to.equal(detectorId, JSON.stringify(res));
+    });
+
+    it('should get detector info using detectorInfo (deprecated for getDetectorInfo)', async function () {
       const res = await this.api.detectorInfo(detectorId);
 
       expect(res.id).to.equal(detectorId, JSON.stringify(res));
     });
 
     it('should get an error with an invalid detector ID', async function () {
-      const res = await this.api.detectorInfo(RANDOM_MONGO_ID);
+      const res = await this.api.getDetectorInfo(RANDOM_MONGO_ID);
 
       expect(res.code).to.equal(INVALID_QUERY_ERR, JSON.stringify(res));
     });
@@ -172,6 +178,15 @@ describe('Detectors', function () {
     });
   });
 
+  describe('listDetectors', function () {
+    it('should list all detectors', async function () {
+      const res = await this.api.listDetectors();
+
+      expect(res).to.be.an('array', JSON.stringify(res));
+      expect(res).to.have.lengthOf.above(0, JSON.stringify(res));
+    });
+  });
+
   describe('deleteDetector', function () {
     it('should delete detector', async function () {
       const res = await cleanUpDetector(this.api, detectorId);
@@ -196,7 +211,7 @@ async function waitDetectorTraining(api, detectorId) {
   // wait until detector is trained
   printInfo('waiting for detector training');
 
-  let res = await api.detectorInfo(detectorId);
+  let res = await api.getDetectorInfo(detectorId);
   let indicator = '\x1b[2m      .';
   const maxTries = 40;
 
@@ -211,7 +226,7 @@ async function waitDetectorTraining(api, detectorId) {
     }
 
     await sleep(5000);
-    res = await api.detectorInfo(detectorId);
+    res = await api.getDetectorInfo(detectorId);
   }
 
   printInfo('detector is ready.');

--- a/test/test-detectors.js
+++ b/test/test-detectors.js
@@ -44,7 +44,6 @@ describe('Detectors', function () {
         detectorName,
         'general'
       );
-
       expect(res.detectorId).to.be.a('string', JSON.stringify(res));
       detectorId = res.detectorId;
       // wait until detector can be edited
@@ -62,11 +61,11 @@ describe('Detectors', function () {
     });
   });
 
-  describe('finalizeDetector', function () {
+  describe('trainDetector', function () {
     this.timeout(300000);
 
     it('should start detector training', async function () {
-      const res = await this.api.finalizeDetector(detectorId);
+      const res = await this.api.trainDetector(detectorId);
 
       expect(res.detectorId).to.equal(detectorId, JSON.stringify(res));
       expect(res.message).to.equal('training began successfully');
@@ -75,7 +74,7 @@ describe('Detectors', function () {
     });
 
     it('should get an error with an invalid detector ID', async function () {
-      const res = await this.api.finalizeDetector(RANDOM_MONGO_ID);
+      const res = await this.api.trainDetector(RANDOM_MONGO_ID);
 
       expect(res.code).to.equal(INVALID_QUERY_ERR, JSON.stringify(res));
     });
@@ -99,15 +98,15 @@ describe('Detectors', function () {
     it('should create a copy of an existing detector', async function () {
       const res = await this.api.redoDetector(detectorId);
 
-      expect(res.detector_id).to.be.a('string', JSON.stringify(res));
+      expect(res.detectorId).to.be.a('string', JSON.stringify(res));
 
-      redoDetectorId = res.detector_id;
+      redoDetectorId = res.detectorId;
     });
 
     it('should get an error with an invalid detectorId', async function () {
       const res = await this.api.redoDetector(RANDOM_MONGO_ID);
 
-      expect(res.code).to.equal(INVALID_QUERY_ERR);
+      expect(res.code).to.equal(INVALID_QUERY_ERR, JSON.stringify(res));
     });
   });
 
@@ -149,13 +148,13 @@ describe('Detectors', function () {
         detectorType,
       });
 
-      expect(res.detector_id).to.be.a('string', JSON.stringify(res));
+      expect(res.detectorId).to.be.a('string', JSON.stringify(res));
       expect(res.message).to.include(
         'Your model is being uploaded',
         JSON.stringify(res)
       );
 
-      importedDetectorId = res.detector_id;
+      importedDetectorId = res.detectorId;
     });
 
     it('should throw an error with invalid params', async function () {

--- a/test/test-images.js
+++ b/test/test-images.js
@@ -24,6 +24,7 @@ describe('Images', function () {
       });
 
       expect(res.results).to.be.an('array', JSON.stringify(res));
+      expect(res.results).to.have.lengthOf(1, JSON.stringify(res));
     });
 
     it('should classify an array of local images', async function () {
@@ -32,6 +33,7 @@ describe('Images', function () {
       });
 
       expect(res.results).to.be.an('array', JSON.stringify(res));
+      expect(res.results).to.have.lengthOf(2, JSON.stringify(res));
     });
 
     it('should classify an online url', async function () {
@@ -40,6 +42,7 @@ describe('Images', function () {
       });
 
       expect(res.results).to.be.an('array', JSON.stringify(res));
+      expect(res.results).to.have.lengthOf(1, JSON.stringify(res));
     });
 
     it('should classify an array of online urls', async function () {
@@ -48,6 +51,7 @@ describe('Images', function () {
       });
 
       expect(res.results).to.be.an('array', JSON.stringify(res));
+      expect(res.results).to.have.lengthOf(2, JSON.stringify(res));
     });
 
     it('should get an error if no images are provided', async function () {
@@ -61,13 +65,40 @@ describe('Images', function () {
   });
 
   describe('localizeImage', function () {
-    it('should classify an image when update is not set to true', async function () {
+    it('should classify a local image when update is not set to true', async function () {
+      const res = await this.api.localizeImage(EVERYDAY_OBJECT_ID, 'cat', {
+        file: CAT_FILE,
+      });
+
+      expect(res.results).to.be.an('array', JSON.stringify(res));
+      expect(res.results).to.have.lengthOf(1, JSON.stringify(res));
+    });
+
+    it('should classify an array of local images when update is not set to true', async function () {
       const res = await this.api.localizeImage(EVERYDAY_OBJECT_ID, 'cat', {
         url: CAT_URL,
       });
 
       expect(res.results).to.be.an('array', JSON.stringify(res));
-      expect(res.results).to.have.lengthOf(1);
+      expect(res.results).to.have.lengthOf(1, JSON.stringify(res));
+    });
+
+    it('should classify an online url when update is not set to true', async function () {
+      const res = await this.api.localizeImage(EVERYDAY_OBJECT_ID, 'cat', {
+        file: CAT_FILE,
+      });
+
+      expect(res.results).to.be.an('array', JSON.stringify(res));
+      expect(res.results).to.have.lengthOf(1, JSON.stringify(res));
+    });
+
+    it('should classify an array of online urls when update is not set to true', async function () {
+      const res = await this.api.localizeImage(EVERYDAY_OBJECT_ID, 'cat', {
+        url: [CAT_URL, DOG_URL],
+      });
+
+      expect(res.results).to.be.an('array', JSON.stringify(res));
+      expect(res.results).to.have.lengthOf(2, JSON.stringify(res));
     });
 
     // { update: true } positive case is tested in test-labels.js, it needs a pending detector/label to test

--- a/test/test-labels.js
+++ b/test/test-labels.js
@@ -188,9 +188,7 @@ describe('Labels', function () {
   //   this.timeout(100000);
 
   //   it('should take an imageId and a labelId', async function () {
-  //     const infoRes = await this.api.getDetectorInfo(detectorId);
-  //     console.log(infoRes.labels)
-  //     console.log(infoRes.labelIds)
+  //     const infoRes = await this.api.detectorInfo(detectorId);
 
   //     const res = await this.api.localizeImage(detectorId, 'new-label', {
   //       update: true,

--- a/test/test-labels.js
+++ b/test/test-labels.js
@@ -184,32 +184,6 @@ describe('Labels', function () {
     });
   });
 
-  // describe('localizeImage', function () {
-  //   this.timeout(100000);
-
-  //   it('should take an imageId and a labelId', async function () {
-  //     const res = await this.api.localizeImage(detectorId, 'cat', {
-  //       update: true,
-  //       imageId,
-  //       labelId,
-  //     });
-
-  //     expect(res.results).to.be.an('Array', JSON.stringify(res));
-  //     expect(res.results).to.have.lengthOf(1, JSON.stringify(res));
-  //   });
-
-  //   it('should take an array of imageIds and a labelId', async function () {
-  //     const res = await this.api.localizeImage(EVERYDAY_OBJECT_ID, 'cat', {
-  //       update: true,
-  //       imageIds: [imageId, 'invalid-id'],
-  //       labelId,
-  //     });
-
-  //     expect(res.results).to.be.an('Array', JSON.stringify(res));
-  //     expect(res.results).to.have.lengthOf(1, JSON.stringify(res));
-  //   });
-  // });
-
   describe('deleteLabel', function () {
     it('should delete a label', async function () {
       const res = await this.api.deleteLabel(detectorId, labelId);

--- a/test/test-labels.js
+++ b/test/test-labels.js
@@ -27,7 +27,7 @@ describe('Labels', function () {
     const res = await this.api.createDetector(
       DETECTOR_ZIP,
       `test-label-detector-${Date.now()}`,
-      'general'
+      'single_shot_detector'
     );
     detectorId = res.detectorId;
     await waitDetectorReadyForEdit(this.api, detectorId);
@@ -72,11 +72,29 @@ describe('Labels', function () {
   });
 
   describe('getAnnotations', function () {
-    it('should get annotations', async function () {
+    it('should get annotations using a labelId', async function () {
       const res = await this.api.getAnnotations({ labelIds: [labelId] });
 
       expect(res.images).to.be.an('Array', JSON.stringify(res));
       expect(res.images).to.have.lengthOf(1, JSON.stringify(res));
+
+      imageId = res.images[0].id;
+    });
+
+    it('should get annotations using a detectorId', async function () {
+      const res = await this.api.getAnnotations({ detectorId });
+
+      expect(res.images).to.be.an('Array', JSON.stringify(res));
+      // two images from detector zip file and one image from the createLabelWithImages test
+      expect(res.images).to.have.lengthOf(3, JSON.stringify(res));
+    });
+
+    it('should get annotations using an imageId', async function () {
+      const res = await this.api.getAnnotations({ imageId });
+
+      expect(res.images).to.be.an('Array', JSON.stringify(res));
+      expect(res.images).to.have.lengthOf(1, JSON.stringify(res));
+      expect(res.images[0].id).to.equal(imageId);
     });
 
     it('should get an error with invalid params', async function () {
@@ -85,7 +103,7 @@ describe('Labels', function () {
       } catch (e) {
         expect(e).to.be.an('Error', JSON.stringify(e));
         expect(e.message).to.equal(
-          'Please pass in one of the ids: detectorId, labelIds, or imageId',
+          'Please pass in one of the following IDs: detectorId, labelIds, or imageId',
           JSON.stringify(e)
         );
       }
@@ -98,8 +116,6 @@ describe('Labels', function () {
 
       expect(res.images).to.be.an('Array', JSON.stringify(res));
       expect(res.images).to.have.lengthOf(1);
-
-      imageId = res.images[0]['imageId'];
     });
 
     it('should throw an error with invalid params', async function () {
@@ -115,7 +131,7 @@ describe('Labels', function () {
     });
   });
 
-  describe('UpdateAnnotations', function () {
+  describe('updateAnnotations', function () {
     it('should update annotations', async function () {
       const res = await this.api.updateAnnotations(detectorId, labelId, [
         { id: imageId, bbox: { left: 0.1, top: 0.1, width: 0.2, height: 0.2 } },
@@ -168,31 +184,35 @@ describe('Labels', function () {
     });
   });
 
-  describe('localizeImage', function () {
-    this.timeout(100000);
+  // describe('localizeImage', function () {
+  //   this.timeout(100000);
 
-    it('should take an imageId and a labelId', async function () {
-      const res = await this.api.localizeImage(EVERYDAY_OBJECT_ID, 'cat', {
-        update: true,
-        imageId,
-        labelId,
-      });
+  //   it('should take an imageId and a labelId', async function () {
+  //     const infoRes = await this.api.getDetectorInfo(detectorId);
+  //     console.log(infoRes.labels)
+  //     console.log(infoRes.labelIds)
 
-      expect(res.results).to.be.an('Array', JSON.stringify(res));
-      expect(res.results).to.have.lengthOf(1, JSON.stringify(res));
-    });
+  //     const res = await this.api.localizeImage(detectorId, 'new-label', {
+  //       update: true,
+  //       imageId,
+  //       labelId,
+  //     });
 
-    it('should take an array of imageIds and a labelId', async function () {
-      const res = await this.api.localizeImage(EVERYDAY_OBJECT_ID, 'cat', {
-        update: true,
-        imageIds: [imageId, 'invalid-id'],
-        labelId,
-      });
+  //     expect(res.results).to.be.an('Array', JSON.stringify(res));
+  //     expect(res.results).to.have.lengthOf(1, JSON.stringify(res));
+  //   });
 
-      expect(res.results).to.be.an('Array', JSON.stringify(res));
-      expect(res.results).to.have.lengthOf(1, JSON.stringify(res));
-    });
-  });
+  //   it('should take an array of imageIds and a labelId', async function () {
+  //     const res = await this.api.localizeImage(EVERYDAY_OBJECT_ID, 'cat', {
+  //       update: true,
+  //       imageIds: [imageId, 'invalid-id'],
+  //       labelId,
+  //     });
+
+  //     expect(res.results).to.be.an('Array', JSON.stringify(res));
+  //     expect(res.results).to.have.lengthOf(1, JSON.stringify(res));
+  //   });
+  // });
 
   describe('deleteLabel', function () {
     it('should delete a label', async function () {

--- a/test/test-labels.js
+++ b/test/test-labels.js
@@ -188,7 +188,7 @@ describe('Labels', function () {
   //   this.timeout(100000);
 
   //   it('should take an imageId and a labelId', async function () {
-  //     const infoRes = await this.api.detectorInfo(detectorId);
+  //     const infoRes = await this.api.getDetectorInfo(detectorId);
 
   //     const res = await this.api.localizeImage(detectorId, 'new-label', {
   //       update: true,

--- a/test/test-labels.js
+++ b/test/test-labels.js
@@ -188,9 +188,7 @@ describe('Labels', function () {
   //   this.timeout(100000);
 
   //   it('should take an imageId and a labelId', async function () {
-  //     const infoRes = await this.api.getDetectorInfo(detectorId);
-
-  //     const res = await this.api.localizeImage(detectorId, 'new-label', {
+  //     const res = await this.api.localizeImage(detectorId, 'cat', {
   //       update: true,
   //       imageId,
   //       labelId,

--- a/test/test-streams.js
+++ b/test/test-streams.js
@@ -1,12 +1,12 @@
 const chai = require('chai');
 const expect = chai.expect;
 const { setUpClient, sleep } = require('./utils');
-const { YOUTUBE_VID_URL, EVERYDAY_OBJECT_ID } = require('./data');
+const { S3_VID_URL, EVERYDAY_OBJECT_ID } = require('./data');
 
 describe('Streams', function () {
   this.timeout(10000);
 
-  let monitoringId, streamId;
+  let streamId, monitoringId;
 
   before(async function () {
     this.api = setUpClient();
@@ -27,7 +27,7 @@ describe('Streams', function () {
   describe('createStream', async function () {
     it('should create a stream', async function () {
       const streamName = `node-test-stream-${Date.now()}`;
-      const res = await this.api.createStream(YOUTUBE_VID_URL, streamName);
+      const res = await this.api.createStream(S3_VID_URL, streamName);
 
       expect(res.streamId).to.be.a('string', JSON.stringify(res));
 
@@ -36,7 +36,7 @@ describe('Streams', function () {
 
     it('should throw an error if missing params', async function () {
       try {
-        await this.api.createStream(YOUTUBE_VID_URL);
+        await this.api.createStream(S3_VID_URL);
       } catch (e) {
         expect(e).to.be.an('Error', JSON.stringify(e));
         expect(e.message).to.equal(

--- a/test/test-streams.js
+++ b/test/test-streams.js
@@ -1,12 +1,12 @@
 const chai = require('chai');
 const expect = chai.expect;
 const { setUpClient, sleep } = require('./utils');
-const { S3_VID_URL, EVERYDAY_OBJECT_ID } = require('./data');
+const { S3_VID_URL, S3_VID_URL_2 , EVERYDAY_OBJECT_ID } = require('./data');
 
 describe('Streams', function () {
   this.timeout(10000);
 
-  let streamId, monitoringId;
+  let streamId, streamId2, monitoringId;
 
   before(async function () {
     this.api = setUpClient();
@@ -22,21 +22,34 @@ describe('Streams', function () {
     if (streamId) {
       await this.api.deleteStream(streamId);
     }
+
+    if (streamId2) {
+      await this.api.deleteStream(streamId2);
+    }
   });
 
-  describe('registerStream', async function () {
+  describe('createStream', async function () {
     it('should create a stream', async function () {
       const streamName = `node-test-stream-${Date.now()}`;
-      const res = await this.api.registerStream(S3_VID_URL, streamName);
+      const res = await this.api.createStream(S3_VID_URL, streamName);
 
       expect(res.streamId).to.be.a('string', JSON.stringify(res));
 
       streamId = res.streamId;
     });
 
+    it('should create a stream using registerStream (deprecated for createStream)', async function () {
+      const streamName = `node-test-stream-${Date.now()}`;
+      const res = await this.api.registerStream(S3_VID_URL_2, streamName);
+
+      expect(res.streamId).to.be.a('string', JSON.stringify(res));
+
+      streamId2 = res.streamId;
+    });
+
     it('should throw an error if missing params', async function () {
       try {
-        await this.api.registerStream(S3_VID_URL);
+        await this.api.createStream(S3_VID_URL);
       } catch (e) {
         expect(e).to.be.an('Error', JSON.stringify(e));
         expect(e.message).to.equal(

--- a/test/test-streams.js
+++ b/test/test-streams.js
@@ -24,10 +24,10 @@ describe('Streams', function () {
     }
   });
 
-  describe('createStream', async function () {
+  describe('registerStream', async function () {
     it('should create a stream', async function () {
       const streamName = `node-test-stream-${Date.now()}`;
-      const res = await this.api.createStream(S3_VID_URL, streamName);
+      const res = await this.api.registerStream(S3_VID_URL, streamName);
 
       expect(res.streamId).to.be.a('string', JSON.stringify(res));
 
@@ -36,7 +36,7 @@ describe('Streams', function () {
 
     it('should throw an error if missing params', async function () {
       try {
-        await this.api.createStream(S3_VID_URL);
+        await this.api.registerStream(S3_VID_URL);
       } catch (e) {
         expect(e).to.be.an('Error', JSON.stringify(e));
         expect(e.message).to.equal(
@@ -62,8 +62,8 @@ describe('Streams', function () {
       const res = await this.api.monitorStream(
         streamId,
         EVERYDAY_OBJECT_ID,
-        { cat: 0.5 },
         {
+          thresholds: { cat: 0.5 },
           taskName: 'node-test-task',
           endTime: '5 minutes',
         }

--- a/test/test-videos.js
+++ b/test/test-videos.js
@@ -1,10 +1,10 @@
 const chai = require('chai');
 const expect = chai.expect;
-const { setUpClient } = require('./utils');
-const { EVERYDAY_OBJECT_ID, YOUTUBE_VID_URL } = require('./data');
+const { setUpClient, waitVideoDoneClassifying } = require('./utils');
+const { EVERYDAY_OBJECT_ID, S3_VID_URL } = require('./data');
 
 describe('Videos', function () {
-  this.timeout(10000);
+  this.timeout(100000);
 
   let videoId;
 
@@ -13,10 +13,14 @@ describe('Videos', function () {
     await this.api.retrieveToken();
   });
 
+  after(async function () {
+    await waitVideoDoneClassifying(this.api, videoId);
+  });
+
   describe('classifyVideo', async function () {
     it('should start classifying a video', async function () {
       const res = await this.api.classifyVideo(EVERYDAY_OBJECT_ID, {
-        url: YOUTUBE_VID_URL,
+        url: S3_VID_URL,
       });
 
       expect(res.videoId).to.be.a('string', JSON.stringify(res));
@@ -24,7 +28,7 @@ describe('Videos', function () {
       videoId = res.videoId;
     });
 
-    it('should throw and error if missing video', async function () {
+    it('should throw an error if missing video', async function () {
       try {
         await this.api.classifyVideo(EVERYDAY_OBJECT_ID);
       } catch (e) {

--- a/test/test-videos.js
+++ b/test/test-videos.js
@@ -43,7 +43,7 @@ describe('Videos', function () {
 
   describe('getVideoResults', async function () {
     it('should get video classification results', async function () {
-      const res = await this.api.getVideoResults(videoId, {
+      const res = await this.api.getVideoResults(videoId, null, null, {
         annotations: true,
       });
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -25,7 +25,7 @@ const printInfo = message => {
 };
 
 const waitDetectorReadyForEdit = async (api, detectorId) => {
-  let res = await api.getDetectorInfo(detectorId);
+  let res = await api.detectorInfo(detectorId);
   
   let tries = 0;
   const maxTries = 15;
@@ -38,7 +38,7 @@ const waitDetectorReadyForEdit = async (api, detectorId) => {
     }
 
     await sleep(2000);
-    res = await api.getDetectorInfo(detectorId);
+    res = await api.detectorInfo(detectorId);
   }
 };
 
@@ -88,6 +88,26 @@ async function waitCollectionTaskStop(api, collectionIndexId) {
   }
 }
 
+async function waitVideoDoneClassifying(api, videoId) {
+  // wait until video is done classifying so it doesn't conflict with future runs b/c of concurrent video classification limit
+  let res = await api.getVideoResults(videoId);
+  let tries = 0;
+  const maxTries = 10;
+
+  const doneStates = ['success', 'failed'];
+  while (!doneStates.includes(res.state)) {
+    if (tries > maxTries) {
+      throw new Error('Timeout when waiting for video to finish classifying');
+    }
+    console.log(res.state)
+
+    await sleep(2000);
+    tries++;
+
+    res = await api.getVideoResults(videoId);
+  }
+};
+
 module.exports = {
   setUpClient,
   sleep,
@@ -96,4 +116,5 @@ module.exports = {
   deletePendingDetector,
   waitIndexDone,
   waitCollectionTaskStop,
+  waitVideoDoneClassifying,
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -26,7 +26,7 @@ const printInfo = message => {
 
 const waitDetectorReadyForEdit = async (api, detectorId) => {
   let res = await api.getDetectorInfo(detectorId);
-
+  
   let tries = 0;
   const maxTries = 15;
   while (res.processing) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,18 +1,18 @@
 const Matroid = require('../dist/matroid');
 
 const setUpClient = () => {
-  let { BASE_URL, CLIENT_ID, CLIENT_SECRET } = process.env;
+  let { BASE_URL, MATROID_CLIENT_ID, MATROID_CLIENT_SECRET } = process.env;
 
   const baseUrl = BASE_URL || 'https://staging.dev.matroid.com/api/v1';
 
-  if (!CLIENT_ID || !CLIENT_SECRET) {
-    throw new Error('Please pass in CLIENT_ID and CLIENT_SECRET');
+  if (!MATROID_CLIENT_ID || !MATROID_CLIENT_SECRET) {
+    throw new Error('Please pass in MATROID_CLIENT_ID and MATROID_CLIENT_SECRET');
   }
 
   return new Matroid({
     baseUrl,
-    clientId: CLIENT_ID,
-    clientSecret: CLIENT_SECRET
+    clientId: MATROID_CLIENT_ID,
+    clientSecret: MATROID_CLIENT_SECRET
   });
 };
 
@@ -34,11 +34,12 @@ const waitDetectorReadyForEdit = async (api, detectorId) => {
     if (tries > maxTries) {
       throw new Error(
         'Timeout when waiting for detector to be ready for editing'
-      );
-    }
-
-    await sleep(2000);
-    res = await api.detectorInfo(detectorId);
+        );
+      }
+      
+      await sleep(2000);
+      res = await api.detectorInfo(detectorId);
+      console.log(res.state)
   }
 };
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -44,6 +44,7 @@ const waitDetectorReadyForEdit = async (api, detectorId) => {
 
 const deletePendingDetector = async api => {
   const res = await api.searchDetectors({ state: 'pending' });
+
   if (res.length) {
     await api.deleteDetector(res[0]['id']);
   }


### PR DESCRIPTION
This PR updates @xiaoyun-matroid's to include all routes/parameters currently specified in the API, and to resolve potential breaking changes.

The breaking changes I noted were the following:
- Renaming `accountInfo` to `getAccountInfo`
- Renaming `detectorInfo` to `getDetectorInfo`
- Renaming `registerStream` to `createStream`
- Different parameters for `getVideoResults`
- Different parameters for `monitorStream`
- Removing `listDetectors` in place of `searchDetectors`